### PR TITLE
MediaQuery child can be a node or func.

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -17,7 +17,7 @@ export const MediaQueryWrapper = (props = {}) => {
 }
 
 MediaQueryWrapper.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   dispatch: PropTypes.func.isRequired,
   fakeWidth: PropTypes.number.isRequired,
 }


### PR DESCRIPTION
Passing a function child currently causes a PropType warning.